### PR TITLE
Force FandomDesktop skin for interactiveVerifyURL

### DIFF
--- a/src/commands/confe/UserVerifyCommand.ts
+++ b/src/commands/confe/UserVerifyCommand.ts
@@ -36,6 +36,8 @@ class UserVerifyCommand extends Command {
     const discordTag = `${message.author.username}#${message.author.discriminator}`;
 
     const interactiveVerifyURL = new URL('https://confederacion-hispana.fandom.com/es/wiki/Especial:VerifyUser');
+
+    interactiveVerifyURL.searchParams.append('useskin', 'fandomdesktop');
     interactiveVerifyURL.searchParams.append('user', message.author.username);
     interactiveVerifyURL.searchParams.append('tag', message.author.discriminator);
     interactiveVerifyURL.searchParams.append('ch', (message.channel as TextChannel).name);

--- a/src/events/MemberUpdateEvent.ts
+++ b/src/events/MemberUpdateEvent.ts
@@ -69,6 +69,7 @@ class MemberUpdateEvent extends Event {
 
       const interactiveVerifyURL = new URL('https://confederacion-hispana.fandom.com/es/wiki/Especial:VerifyUser');
 
+      interactiveVerifyURL.searchParams.append('useskin', 'fandomdesktop');
       interactiveVerifyURL.searchParams.append('user', newMember.user.username);
       interactiveVerifyURL.searchParams.append('tag', newMember.user.discriminator);
       interactiveVerifyURL.searchParams.append('ch', (client.channels.resolve(env.VERIF_CHANNEL) as TextChannel).name);


### PR DESCRIPTION
Added `?useskin=fandomdesktop` to interactiveVerifyURL, so users trying to verify from a mobile device won't see an error page (since FandomMobile doesn't load site JS).
